### PR TITLE
Set server hostname even if /etc/hostname is not present.

### DIFF
--- a/lib/chef/knife/bootstrap/chef-server-debian.erb
+++ b/lib/chef/knife/bootstrap/chef-server-debian.erb
@@ -29,7 +29,7 @@ set_hostname_for_ubuntu() {
   local host_first="$(echo $hostname | cut -d . -f 1)"
   local hostnames="${hostname} ${host_first}"
 
-  sed -i "s/^.*$/$hostname/" /etc/hostname
+  echo $hostname > /etc/hostname
   if egrep -q "^127.0.1.1[[:space:]]" /etc/hosts >/dev/null ; then
     sed -i "s/^\(127[.]0[.]1[.]1[[:space:]]\+\)/\1${hostnames} /" \
       /etc/hosts


### PR DESCRIPTION
On Ubuntu images from Linode `/etc/hostname` file is not present and script fails to set hostname due to sed's behavior - if file is not present or empty it won't do a substitution. I'm bad at sed's black magic so I've added a straightforward `echo $hostname > /etc/hostname` if it is wrong or it could be done in a better way with sed feel free to change it. As I understand script should just set the hostname file contents independent of whether it is present or already have something in it in this case I think `echo` is just fine.

Thanks for a great tool!
