### PR TITLE
Pass SSH identity file option to Knife::Server::SSH

### DIFF
--- a/lib/chef/knife/server_bootstrap_ec2.rb
+++ b/lib/chef/knife/server_bootstrap_ec2.rb
@@ -162,7 +162,8 @@ class Chef
         ::Knife::Server::SSH.new(
           :host => server_dns_name,
           :user => config[:ssh_user],
-          :port => config[:ssh_port]
+          :port => config[:ssh_port],
+          :keys => [config[:identity_file]]
         )
       end
     end

--- a/lib/chef/knife/server_bootstrap_standalone.rb
+++ b/lib/chef/knife/server_bootstrap_standalone.rb
@@ -92,7 +92,8 @@ class Chef
           :host => config[:host],
           :user => config[:ssh_user],
           :password => config[:ssh_password],
-          :port => config[:ssh_port]
+          :port => config[:ssh_port],
+          :keys => [config[:identity_file]]
         )
       end
     end


### PR DESCRIPTION
This fixes authentication errors when using the `--identity-file` option with bootstrap commands. If no option is given, an array containing `nil` will be passed as the list of private keys to try and Net::SSH seems to handle that correctly.
