### PR TITLE
Merge server config to Ec2ServerCreate config

### DIFF
--- a/lib/chef/knife/server_bootstrap_ec2.rb
+++ b/lib/chef/knife/server_bootstrap_ec2.rb
@@ -112,9 +112,7 @@ class Chef
         ENV['WEBUI_PASSWORD'] = config[:webui_password]
         ENV['AMQP_PASSWORD'] = config[:amqp_password]
         bootstrap = Chef::Knife::Ec2ServerCreate.new
-        [ :chef_node_name, :ssh_user, :ssh_port, :identity_file,
-          :security_groups, :ebs_size, :webui_password, :amqp_password
-        ].each { |attr| bootstrap.config[attr] = config[attr] }
+        bootstrap.config.merge!(config)
         bootstrap.config[:tags] = bootstrap_tags
         bootstrap.config[:distro] = bootstrap_distro
         bootstrap


### PR DESCRIPTION
Ec2ServerCreate pulls its configs for some items in a way that the options specified on the command line won't get propagated. This is easily fixed by simply merge our config up to the bootstrap object's config.
