### PR TITLE
Fix knife-ec2 gem requirements

### DIFF
--- a/knife-server.gemspec
+++ b/knife-server.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "fog",       "~> 1.3"
   gem.add_dependency "net-ssh"
   gem.add_dependency "chef",      ">= 0.10.10"
-  gem.add_dependency "knife-ec2", "~> 0.5.12"
+  gem.add_dependency "knife-ec2", ">= 0.5.12"
 
   gem.add_development_dependency "rspec", "~> 2.10"
   gem.add_development_dependency "fakefs", "~> 0.4.0"


### PR DESCRIPTION
No need for such a restrictive 0.5.x requirement, works fine with knife-ec2 v 0.6.x as well.
