### PR TITLE
Identity fix

### DIFF
--- a/lib/chef/knife/server_bootstrap_standalone.rb
+++ b/lib/chef/knife/server_bootstrap_standalone.rb
@@ -93,7 +93,7 @@ class Chef
           :user => config[:ssh_user],
           :password => config[:ssh_password],
           :port => config[:ssh_port],
-          :keys => [config[:identity_file]]
+          :keys => [config[:identity_file]].compact
         )
       end
     end

--- a/spec/chef/knife/server_bootstrap_standalone_spec.rb
+++ b/spec/chef/knife/server_bootstrap_standalone_spec.rb
@@ -206,7 +206,7 @@ describe Chef::Knife::ServerBootstrapStandalone do
       it "creates an SSH connection without a password" do
         Knife::Server::SSH.should_receive(:new).with({
           :host => "192.168.0.1", :port => "2345",
-          :user => "root", :password => nil, :keys => [nil]
+          :user => "root", :password => nil, :keys => []
         })
 
         @knife.run
@@ -221,7 +221,7 @@ describe Chef::Knife::ServerBootstrapStandalone do
       it "creates an SSH connection with a password" do
         Knife::Server::SSH.should_receive(:new).with({
           :host => "192.168.0.1", :port => "2345",
-          :user => "root", :password => "snoopy", :keys => [nil]
+          :user => "root", :password => "snoopy", :keys => []
         })
 
         @knife.run


### PR DESCRIPTION
This fixes bug #14 -- ran into this doing chef-workflow stuff.

Basically, if you're able to pass a nil to net-ssh's keys array, it barfs trying to coerce it to a string. Probably should be fixed upstream but net-ssh... yeah :)

Anyhow, I also fixed the tests where I assumed nils would be ok. Working fine after the fix for my use cases.

If you could release after this one, that'd be great -- basically if you don't supply the argument, it exhibits this error -- passing any non-nil argument works for now, but it's rather confusing for people who don't know what's going on.
