### PR TITLE
Auto select bootstrap template

### DIFF
--- a/lib/chef/knife/bootstrap/chef10/rhel.erb
+++ b/lib/chef/knife/bootstrap/chef10/rhel.erb
@@ -28,7 +28,9 @@ setup() {
   yum install ruby rubygems ruby-devel -y
   yum install readline-devel zlib-devel libyaml-devel openssl-devel \
     make autoconf automake gcc tar libstdc++-devel gcc-c++ -y
-  /usr/bin/gem update --system
+
+  /usr/bin/gem install rubygems-update -v 1.8.25
+  /usr/bin/update_rubygems
 }
 
 set_hostname_for_centos() {


### PR DESCRIPTION
/cc @fnichol
/cc @danryan

This is a merge of #19, #20, and #21 with a new feature that is the default, `--platform auto`.

How this works:
- ssh connection is made to machine
- shell against `/dev/stdin` (or portable alternative) is started
- a variation (`auto.sh`) on opscode's omnibus `install.sh` is used to detect the platform and platform version
- at the end of the script the platform and platform version are sent to the stdout, new line separated
- presuming the exit status of the shell process is 0 and the two lines exist, platform (for now, version can come later if necessary) is coerced based on the result similar to the way `platform_family?` works in chef
- taking in the new chef11/omnibus functionality @fnichol wrote, generates a template filename of `chef$version/$platform` which is assigned to the `distro` option of the bootstrapper
- at this point the system functions just like it was passed a normal distro template.
- there is a predicate called "bootstrap_auto?" which merely exists to assist people who might have a need to determine if this is an auto bootstrap without having to dive through options hashes and so forth. it's tested but un-used.

Note this flow only happens when `--platform` is set to `auto`, which now happens to be the default. Otherwise things are only changed in relationship to how `--platform` and `--chef-server-version` are set.

The latter argument is just way to say what version of chef you want to run on the chef-server. If greater than '10' it flips the omnibus bit so the bootstrap is different where it matters. The number provided is also used for figuring out what template directory to look in.

Template directories were arranged as such:
- chef10/
  - debian.erb
  - rhel.erb
- chef11/
  - debian.erb

No modifications to the templates were made in this patch set -- the ones that are made in this PR are from the earlier pull requests.

Chef 10 is the default `chef_server_version`. `-C` is a short alias to setting it.

`auto.sh` is commented to note its relationship to the opscode product they use for omnibus chef-client bootstraps.

Tests are green and a few more were added to test the platform selection code. There's probably a good case for moving that stuff to its own spec file, but I'm probably not the person to make that decision. I also tested precise and centos 6 by hand, chef 11 on precise, and against omnios as a refutation (it fails complaining there's no chef10/solaris template, which is what should happen).

Anyhow, let me know if there are any questions or concerns.
