### PR TITLE
copy the existing UI object to knife bootstrap invocation during standalone server bootstrap.

### DIFF
--- a/lib/chef/knife/bootstrap/chef10/debian.erb
+++ b/lib/chef/knife/bootstrap/chef10/debian.erb
@@ -1,4 +1,4 @@
-bash -c '
+bash <<'EOS'
 <%
   require 'erb'
 
@@ -45,7 +45,7 @@ add_opscode_apt_repo() {
   apt-get update
   # permanent upgradeable keyring
   apt-get install -y --force-yes opscode-keyring
-  apt-get upgrade -y
+  apt-get dist-upgrade -y
 }
 
 preseed_chef_pkg() {
@@ -64,7 +64,8 @@ PRESEED
 install_chef_server() {
   preseed_chef_pkg
 
-  apt-get install -y --force-yes chef chef-server libshadow-ruby1.8
+  apt-get update
+  apt-get install -y chef chef-server libshadow-ruby1.8
 }
 
 config_chef_solo() {
@@ -106,4 +107,4 @@ install_chef_server
 enable_ssl_proxy
 
 banner "Bootstraping Chef Server on ${hostname} is complete."
-'
+EOS

--- a/lib/chef/knife/server_bootstrap_standalone.rb
+++ b/lib/chef/knife/server_bootstrap_standalone.rb
@@ -52,8 +52,9 @@ class Chef
       end
 
       def standalone_bootstrap
-        ENV['WEBUI_PASSWORD'] = config[:webui_password]
-        ENV['AMQP_PASSWORD'] = config[:amqp_password]
+        ENV['WEBUI_PASSWORD'] = config[:webui_password] || options[:webui_password][:default]
+        ENV['AMQP_PASSWORD'] = config[:amqp_password] || options[:amqp_password][:default]
+
         bootstrap = Chef::Knife::Bootstrap.new
         bootstrap.name_args = [ config[:host] ]
         Chef::Knife::Bootstrap.options.keys.each do |attr|

--- a/lib/chef/knife/server_bootstrap_standalone.rb
+++ b/lib/chef/knife/server_bootstrap_standalone.rb
@@ -59,6 +59,7 @@ class Chef
         Chef::Knife::Bootstrap.options.keys.each do |attr|
           bootstrap.config[attr] = config_val(attr)
         end
+        bootstrap.ui = self.ui
         bootstrap.config[:distro] = bootstrap_distro
         bootstrap.config[:use_sudo] = true unless config_val(:ssh_user) == "root"
         bootstrap

--- a/spec/chef/knife/server_bootstrap_standalone_spec.rb
+++ b/spec/chef/knife/server_bootstrap_standalone_spec.rb
@@ -107,6 +107,10 @@ describe Chef::Knife::ServerBootstrapStandalone do
       bootstrap.should be_a(Chef::Knife::Bootstrap)
     end
 
+    it "copies our UI object to the bootstrap object" do
+      bootstrap.ui.object_id.should eq(@knife.ui.object_id)
+    end
+
     it "configs the bootstrap's chef_node_name" do
       bootstrap.config[:chef_node_name].should eq("shave.yak")
     end
@@ -209,7 +213,7 @@ describe Chef::Knife::ServerBootstrapStandalone do
     end
 
     let(:bootstrap) do
-      stub(:run => true, :config => Hash.new, :name_args= => true)
+      stub(:run => true, :config => Hash.new, :ui= => true, :name_args= => true)
     end
 
     let(:ssh)         { stub(:exec! => true) }


### PR DESCRIPTION
this keeps the same UI object through the whole knife-server bootstrap process. I set it when I invoke knife-server (as I do with many other knife bits), but the internals here don't allow me to fix this specific case. I need this to redirect to logging facilities.

It works, I have code here that tests it by side effect and verifies it works, and it alters no functionality from the end-user perspective.

The only problem here is that this patch works great, but the mocks are actually breaking it in the test suite. If you have any ideas how I can resolve this, that'd be great.

I do need this soonish and if we can resolve the mocking issue in a way that leaves you happy, I could really use a release after this patch is merged.

Thanks again.
