### PR TITLE
Do not blindly transfer options that have not been provided i.e. is nil

### DIFF
--- a/lib/chef/knife/server_bootstrap_ec2.rb
+++ b/lib/chef/knife/server_bootstrap_ec2.rb
@@ -72,7 +72,8 @@ class Chef
         ENV['NO_TEST'] = "1" if config[:no_test]
         bootstrap = Chef::Knife::Ec2ServerCreate.new
         Chef::Knife::Ec2ServerCreate.options.keys.each do |attr|
-          bootstrap.config[attr] = config_val(attr)
+          val = config_val(attr)
+          bootstrap.config[attr] = val unless val.nil?
         end
         bootstrap.config[:tags] = bootstrap_tags
         bootstrap.config[:distro] = bootstrap_distro


### PR DESCRIPTION
The ec2 bootstrap routine sets options on the plugin that have not been provided on the command line i.e. are nil.
This change avoids that so that the plugin runs ONLY with the actual options provided or which have good defaults.
