### PR TITLE
Fixed Omnibus Installation for RHEL

### DIFF
--- a/lib/chef/knife/bootstrap/_omnibus.sh
+++ b/lib/chef/knife/bootstrap/_omnibus.sh
@@ -43,7 +43,7 @@ failed_download() {
 is_server_installed() {
   if [ -f "/opt/chef-server/bin/chef-server-ctl" ] ; then
     return 0
-  elif [ -f "/opt/opscode/bin/chef-server-ctl" ] ; then
+  elif [ -f "/opt/opscode/bin/private-chef-ctl" ] ; then
     return 0
   else
     return 1
@@ -107,7 +107,7 @@ install_package() {
 detect_info() {
   if [ -f "/opt/chef-server/bin/chef-server-ctl" ] ; then
     server_root="/opt/chef-server"
-  elif [ -f "/opt/opscode/bin/chef-server-ctl" ] ; then
+  elif [ -f "/opt/opscode/bin/private-chef-ctl" ] ; then
     server_root="/opt/opscode"
   fi
 

--- a/lib/chef/knife/bootstrap/_omnibus.sh
+++ b/lib/chef/knife/bootstrap/_omnibus.sh
@@ -124,6 +124,9 @@ patch_knife_code() {
   if [ -f "$patched" ]; then
     info "Patched knife configure detected, skipping"
   elif echo "$script" | $server_root/embedded/bin/ruby -r chef/version; then
+    if [[ "$platform" == "el" ]]; then
+      yum install -y patch
+    fi
     info "Patching knife configure bug (CHEF-5211)"
     (cd $gems/chef-11.* && cat <<PATCH | tr "#" "\047" | patch -p1)
 diff --git a/lib/chef/knife/configure.rb b/lib/chef/knife/configure.rb

--- a/lib/chef/knife/bootstrap/_omnibus.sh
+++ b/lib/chef/knife/bootstrap/_omnibus.sh
@@ -107,8 +107,10 @@ install_package() {
 detect_info() {
   if [ -f "/opt/chef-server/bin/chef-server-ctl" ] ; then
     server_root="/opt/chef-server"
+    server_ctl="chef-server-ctl"
   elif [ -f "/opt/opscode/bin/private-chef-ctl" ] ; then
     server_root="/opt/opscode"
+    server_ctl="private-chef-ctl"
   fi
 
   info "Chef Server detected in $server_root"
@@ -169,13 +171,13 @@ symlink_binaries() {
 
 reconfigure_chef_server() {
   banner "Reconfiguring Chef Server"
-  chef-server-ctl reconfigure
+  ${server_root}/bin/${server_ctl} reconfigure
   info "Server reconfigured"
 }
 
 test_chef_server() {
   banner "Testing Chef Server"
-  chef-server-ctl test
+  ${server_root}/bin/${server_ctl} test
   info "Pedant suite finished"
 }
 


### PR DESCRIPTION
I had been unable to use the `knife server` tool to build a new Chef server on a RHEL-compatible system. Tweaking the templates locally I was able to finally complete the entire process successfully.

Submitting for your approval, if there's any additional changes you think might be worth adding, please let me know!
